### PR TITLE
remote: workaround to debug x86_64 architecture for the linux kernel

### DIFF
--- a/gdb/remote.c
+++ b/gdb/remote.c
@@ -8034,10 +8034,32 @@ remote_target::process_g_packet (struct regcache *regcache)
   buf_len = strlen (rs->buf);
 
   /* Further sanity checks, with knowledge of the architecture.  */
+  /* HACKFIX for changing architectures for qemu. It's ugly.
+   * Don't use, unless you have to.
+   * Just a tiny modification of the patch of Matias Vara
+   * (http://forum.osdev.org/viewtopic.php?f=13&p=177644)
+   */
   if (buf_len > 2 * rsa->sizeof_g_packet)
-    error (_("Remote 'g' packet reply is too long (expected %ld bytes, got %d "
-	     "bytes): %s"), rsa->sizeof_g_packet, buf_len / 2, rs->buf);
+    {
+      warning (_("Assuming long-mode change. [Remote 'g' packet reply is too long: %s]"), rs->buf);
+      rsa->sizeof_g_packet = buf_len;
 
+      for (i = 0; i < gdbarch_num_regs (gdbarch); i++)
+        {
+          if (rsa->regs[i].pnum == -1)
+            continue;
+
+          if (rsa->regs[i].offset >= rsa->sizeof_g_packet)
+            rsa->regs[i].in_g_packet = 0;
+          else
+            rsa->regs[i].in_g_packet = 1;
+        }
+
+      /* HACKFIX: Make sure at least the lower half of EIP is set correctly,
+       * so the proer breakpoint is recognized (and triggered).
+       */
+      rsa->regs[8].offset = (16 * 8);
+    }
   /* Save the size of the packet sent to us by the target.  It is used
      as a heuristic when determining the max size of packets that the
      target can safely receive.  */


### PR DESCRIPTION
This didn't seem to be fixed since 2012 Mar.
Attach gdbserver on qemu from client and set a breakpoint in
start_kernel function but it will be failed with below error:
(gdb) c
 Remote 'g' packet reply is too long: 00004082fffffff
 ...

Refer https://wiki.osdev.org/QEMU_and_GDB_in_long_mode OS-Dev wiki
to fix issue with workaround patch.

### My Scenario for kernel debugging
- Build binutild-gdb after apply the patch for fixing issue
```bash
$ ./configure
$ make -j8 && sudo make install
```
- the gdb binary will be installed in /usr/local/bin/gdb

- Run qemu for x86_64 architecture
```bash
$ qemu-system-x86_64 -s -S -kernel arch/x86/boot/bzImage -boot c -m 2049M \
   -hda ../buildroot/output/images/rootfs.ext2 \
   -append "root=/dev/sda rw console=ttyS0,115200 acpi=off nokaslr" \
   -serial stdio -display none
```

- Run gdb with ./vmlinux
```bash
$ cd /path/to/linux/kernel/top
$ gdb ./vmlinux
(gdb) target remote :1234
(gdb) b start_kernel
Breakpoint 1 at 0xffffffff82973ac0: file init/main.c, line 538.
(gdb) c
Breakpoint 1, start_kernel () at init/main.c:538
538	{
(gdb) list
533	{
534		rest_init();
535	}
536	
537	asmlinkage __visible void __init start_kernel(void)
538	{
539		char *command_line;
540		char *after_dashes;
541	
542		set_task_stack_end_magic(&init_task);
```