### PR TITLE
fixbugs Finding section exceptions when strip removing information

### DIFF
--- a/binutils/objcopy.c
+++ b/binutils/objcopy.c
@@ -3453,12 +3453,12 @@ copy_object (bfd *ibfd, bfd *obfd, const bfd_arch_info_type *input_arch)
 	  /* It is likely that output sections are in the same order
 	     as the input sections, but do not assume that this is
 	     the case.  */
-	  if (merged->sec->output_section != osec)
+	  if (merged->sec->output_section != osec || merged->sec->index != osec->index)
 	    {
 	      for (merged = merged_note_sections;
 		   merged != NULL;
 		   merged = merged->next)
-		if (merged->sec->output_section == osec)
+		if (merged->sec->output_section == osec && merged->sec->index == osec->index)
 		  break;
 
 	      if (merged == NULL)


### PR DESCRIPTION
strip去除信息时出现异常
```
strip -g /root/rpmbuild/BUILDROOT/glibc-2.28-226.cy8.aarch64/usr/lib64/gcrt1.o
strip:/root/rpmbuild/BUILDROOT/glibc-2.28-226.cy8.aarch64/usr/lib64/stViQ9wt[.gnu.build.attributes.hot]: error: failed to copy merged notes into output: Bad value
```

The reason is that this elf has a section with a duplicate name that needs to be removed
```
[root@localhost ~]# readelf -t ./gcrt1.o |grep attributes.hot
  [63] .gnu.build.attributes.hot
  [64] .rela.gnu.build.attributes.hot
  [71] .gnu.build.attributes.hot
  [72] .rela.gnu.build.attributes.hot
  [79] .gnu.build.attributes.hot
  [80] .rela.gnu.build.attributes.hot
```

Merged_ Note_ Sections are inverted linked lists, while obfd ->sections are positive linked lists, and there will be sections that need to be processed if errors are found