### PR TITLE
Adding clone3 and rseq system call support.

### DIFF
--- a/gdb/amd64-linux-tdep.c
+++ b/gdb/amd64-linux-tdep.c
@@ -1435,6 +1435,14 @@ amd64_canonicalize_syscall (enum amd64_syscall syscall_number)
   case amd64_x32_sys_move_pages:
     return gdb_sys_move_pages;
 
+  case amd64_sys_clone3:
+  case amd64_x32_sys_clone3:
+    return gdb_sys_clone3;
+
+  case amd64_sys_rseq:
+  case amd64_x32_sys_rseq:
+    return gdb_sys_rseq;
+
   default:
     return gdb_sys_no_syscall;
   }

--- a/gdb/amd64-linux-tdep.h
+++ b/gdb/amd64-linux-tdep.h
@@ -321,7 +321,9 @@ enum amd64_syscall {
   amd64_sys_vmsplice = 278,
   amd64_sys_move_pages = 279,
   amd64_sys_pipe2 = 293,
-  amd64_sys_getrandom = 318
+  amd64_sys_getrandom = 318,
+  amd64_sys_clone3 = 435,
+  amd64_sys_rseq = 334,
 };
 
 /* Enum that defines the syscall identifiers for x32 linux.
@@ -571,6 +573,8 @@ enum amd64_x32_syscall {
   amd64_x32_sys_splice = (amd64_x32_syscall_bit + 275),
   amd64_x32_sys_tee = (amd64_x32_syscall_bit + 276),
   amd64_x32_sys_sync_file_range = (amd64_x32_syscall_bit + 277),
+  amd64_x32_sys_rseq = (amd64_x32_syscall_bit + 334),
+  amd64_x32_sys_clone3 = (amd64_x32_syscall_bit + 435),
   amd64_x32_sys_rt_sigaction = (amd64_x32_syscall_bit + 512),
   amd64_x32_sys_rt_sigreturn = (amd64_x32_syscall_bit + 513),
   amd64_x32_sys_ioctl = (amd64_x32_syscall_bit + 514),

--- a/gdb/linux-record.c
+++ b/gdb/linux-record.c
@@ -2047,6 +2047,12 @@ Do you want to stop the program?"),
     case gdb_sys_inotify_init1:
       break;
 
+    case gdb_sys_clone3:
+      break;
+
+    case gdb_sys_rseq:
+      break;
+
     default:
       gdb_printf (gdb_stderr,
 		  _("Process record and replay target doesn't "

--- a/gdb/linux-record.h
+++ b/gdb/linux-record.h
@@ -541,6 +541,8 @@ enum gdb_syscall {
   gdb_sys_msgctl = 531,
   gdb_sys_semtimedop = 532,
   gdb_sys_newfstatat = 540,
+  gdb_sys_clone3 = 541,
+  gdb_sys_rseq = 542,
 };
 
 /* Record a linux syscall.  */


### PR DESCRIPTION
Add the system call numbers and gdb enum entries for clone and rseq system call for record mode. Without this gdb in record mode says 
"Process record and replay target doesn't support syscall number 435
Process record: failed to record execution log."
