### PR TITLE
Add support for Qualcomm uC Xqccmp extension.

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -1282,6 +1282,9 @@ static struct riscv_implicit_subset riscv_implicit_subsets[] =
   {"svade", "+zicsr", check_implicit_always},
   {"svadu", "+zicsr", check_implicit_always},
   {"svbare", "+zicsr", check_implicit_always},
+
+  {"xqccmp", "+zca",  check_implicit_always},
+
   {NULL, NULL, NULL}
 };
 
@@ -1513,6 +1516,7 @@ static struct riscv_supported_ext riscv_supported_vendor_x_ext[] =
   {"xsfvqmaccqoq",	ISA_SPEC_CLASS_DRAFT,	1, 0, 0},
   {"xsfvqmaccdod",	ISA_SPEC_CLASS_DRAFT,	1, 0, 0},
   {"xsfvfnrclipxfqf",	ISA_SPEC_CLASS_DRAFT,	1, 0, 0},
+  {"xqccmp",	ISA_SPEC_CLASS_DRAFT,	0, 1, 0 },
   {NULL, 0, 0, 0, 0}
 };
 
@@ -2121,6 +2125,13 @@ riscv_parse_check_conflicts (riscv_parse_subset_t *rps)
     {
       rps->error_handler
 	(_("`xtheadvector' is conflict with the `v' extension"));
+      no_conflict = false;
+    }
+  if (riscv_subset_supports (rps, "xqccmp")
+      && riscv_subset_supports (rps, "zcd"))
+    {
+      rps->error_handler
+	(_("xqccmp' is incompatible with `zcd' extension"));
       no_conflict = false;
     }
 
@@ -2812,6 +2823,8 @@ riscv_multi_subset_supports (riscv_parse_subset_t *rps,
       return riscv_subset_supports (rps, "xsfvqmaccdod");
     case INSN_CLASS_XSFVFNRCLIPXFQF:
       return riscv_subset_supports (rps, "xsfvfnrclipxfqf");
+    case INSN_CLASS_XQCCMP:
+      return riscv_subset_supports (rps, "xqccmp");
     default:
       rps->error_handler
         (_("internal: unreachable INSN_CLASS_*"));
@@ -3107,6 +3120,8 @@ riscv_multi_subset_supports_ext (riscv_parse_subset_t *rps,
       return "xtheadzvamo";
     case INSN_CLASS_XSFCEASE:
       return "xsfcease";
+    case INSN_CLASS_XQCCMP:
+      return "xqccmp";
     default:
       rps->error_handler
         (_("internal: unreachable INSN_CLASS_*"));

--- a/gas/NEWS
+++ b/gas/NEWS
@@ -2,6 +2,8 @@
 
 * Add support for the x86 Zhaoxin PadLock XMODX instructions.
 
+* Add support for the RISC-V Qualcomm uC xqccmp extension, version 0.1.0.
+
 Changes in 2.44:
 
 * Add support for the x86 Intel Diamond Rapids AMX instructions, including

--- a/gas/testsuite/gas/riscv/march-help.l
+++ b/gas/testsuite/gas/riscv/march-help.l
@@ -166,3 +166,4 @@ All available -march extensions for RISC-V:
 	xsfvqmaccqoq                            1.0
 	xsfvqmaccdod                            1.0
 	xsfvfnrclipxfqf                         1.0
+	xqccmp                                  0.1

--- a/gas/testsuite/gas/riscv/xqccmp.d
+++ b/gas/testsuite/gas/riscv/xqccmp.d
@@ -1,0 +1,17 @@
+#as: -march=rv32i_xqccmp
+#source: xqccmp.s
+#objdump: -dr -Mno-aliases
+
+.*:[	 ]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[	 ]*[0-9a-f]+:[	 ]+ba42[	 ]+qc.cm.pop[	 ]+\{ra\},16
+[	 ]*[0-9a-f]+:[	 ]+be42[	 ]+qc.cm.popret[	 ]+\{ra\},16
+[	 ]*[0-9a-f]+:[	 ]+bc42[	 ]+qc.cm.popretz[	 ]+\{ra\},16
+[	 ]*[0-9a-f]+:[	 ]+b942[	 ]+qc.cm.pushfp[	 ]+\{ra\},16
+[	 ]*[0-9a-f]+:[	 ]+b842[	 ]+qc.cm.push[	 ]+\{ra\},-16
+[	 ]*[0-9a-f]+:[	 ]+ac7e[	 ]+qc.cm.mva01s[	 ]+s0,s7
+[	 ]*[0-9a-f]+:[	 ]+afa2[	 ]+qc.cm.mvsa01[	 ]+s7,s0

--- a/gas/testsuite/gas/riscv/xqccmp.s
+++ b/gas/testsuite/gas/riscv/xqccmp.s
@@ -1,0 +1,9 @@
+target:
+
+	qc.cm.pop {ra}, 16
+	qc.cm.popret {ra}, 16
+	qc.cm.popretz {ra}, 16
+	qc.cm.pushfp {ra}, -16
+	qc.cm.push {ra}, -16
+	qc.cm.mva01s s0,s7
+	qc.cm.mvsa01 s7,s0

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -3786,6 +3786,21 @@
 #define MASK_SFVFNRCLIPXUFQF 0xfe00707f
 #define MATCH_SFVFNRCLIPXFQF 0x8e00505b
 #define MASK_SFVFNRCLIPXFQF 0xfe00707f
+/* qualcomm uC Xqccmp */
+#define MATCH_QC_CM_MVA01S 0xac62
+#define MASK_QC_CM_MVA01S 0xfc63
+#define MATCH_QC_CM_MVSA01 0xac22
+#define MASK_QC_CM_MVSA01 0xfc63
+#define MATCH_QC_CM_POP 0xba02
+#define MASK_QC_CM_POP 0xff03
+#define MATCH_QC_CM_POPRET 0xbe02
+#define MASK_QC_CM_POPRET 0xff03
+#define MATCH_QC_CM_POPRETZ 0xbc02
+#define MASK_QC_CM_POPRETZ 0xff03
+#define MATCH_QC_CM_PUSH 0xb802
+#define MASK_QC_CM_PUSH 0xff03
+#define MATCH_QC_CM_PUSHFP 0xb902
+#define MASK_QC_CM_PUSHFP 0xff03
 /* Unprivileged Counter/Timers CSR addresses.  */
 #define CSR_CYCLE 0xc00
 #define CSR_TIME 0xc01

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -561,6 +561,7 @@ enum riscv_insn_class
   INSN_CLASS_XSFVQMACCQOQ,
   INSN_CLASS_XSFVQMACCDOD,
   INSN_CLASS_XSFVFNRCLIPXFQF,
+  INSN_CLASS_XQCCMP,
 };
 
 /* This structure holds information for a particular instruction.  */

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -3510,6 +3510,15 @@ const struct riscv_opcode riscv_opcodes[] =
 {"sf.vfnrclip.xu.f.qf", 0, INSN_CLASS_XSFVFNRCLIPXFQF, "Vd,Vt,S", MATCH_SFVFNRCLIPXUFQF, MASK_SFVFNRCLIPXUFQF, match_opcode, 0},
 {"sf.vfnrclip.x.f.qf",  0, INSN_CLASS_XSFVFNRCLIPXFQF, "Vd,Vt,S", MATCH_SFVFNRCLIPXFQF, MASK_SFVFNRCLIPXFQF, match_opcode, 0},
 
+/* qualcomm uC Xqccmp */
+{"qc.cm.mva01s", 0, INSN_CLASS_XQCCMP, "Wc1,Wc2", MATCH_QC_CM_MVA01S, MASK_QC_CM_MVA01S, match_opcode, 0},
+{"qc.cm.mvsa01", 0, INSN_CLASS_XQCCMP, "Wc1,Wc2", MATCH_QC_CM_MVSA01, MASK_QC_CM_MVSA01, match_sreg1_not_eq_sreg2, 0},
+{"qc.cm.pop", 0, INSN_CLASS_XQCCMP, "{Wcr},Wcp", MATCH_QC_CM_POP, MASK_QC_CM_POP, match_opcode, 0},
+{"qc.cm.popret", 0, INSN_CLASS_XQCCMP, "{Wcr},Wcp", MATCH_QC_CM_POPRET, MASK_QC_CM_POPRET, match_opcode, 0},
+{"qc.cm.popretz", 0, INSN_CLASS_XQCCMP, "{Wcr},Wcp", MATCH_QC_CM_POPRETZ, MASK_QC_CM_POPRETZ, match_opcode, 0},
+{"qc.cm.push", 0, INSN_CLASS_XQCCMP, "{Wcr},Wcp", MATCH_QC_CM_PUSH, MASK_QC_CM_PUSH, match_opcode, 0},
+{"qc.cm.pushfp", 0, INSN_CLASS_XQCCMP, "{Wcr},Wcp", MATCH_QC_CM_PUSHFP, MASK_QC_CM_PUSHFP, match_opcode, 0},
+
 /* Terminate the list.  */
 {0, 0, INSN_CLASS_NONE, 0, 0, 0, 0, 0}
 };


### PR DESCRIPTION
This implements the Qualcomm uC Xqccmp extensons, version 0.1.0[1]

[1]https://github.com/quic/riscv-unified-db/releases/tag/Xqccmp_extension-0.1.0